### PR TITLE
FIX: Networking on macos needs entitlements.

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -3,6 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
+	<key>com.apple.security.network.server</key>
+	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The app could run on MacOs but not connect to e-hentai nor exhentai. 
It turns out that macos needs entitlements in order to do that.
This little change makes this app work on macos.

Tested on Mac Mini M1 running Monterey 12.4. 
(Keyboard works fine :) ) 