### PR TITLE
Make the some paths to `ApplicationDocumentsDirectory/FEhViewer`

### DIFF
--- a/lib/common/global.dart
+++ b/lib/common/global.dart
@@ -140,7 +140,10 @@ class Global {
     ));
 
     appSupportPath = (await getApplicationSupportDirectory()).path;
-    appDocPath = (await getApplicationDocumentsDirectory()).path;
+    final defaultAppDocPath = (await getApplicationDocumentsDirectory()).path;
+    appDocPath = Platform.isWindows
+        ? path.join(defaultAppDocPath, EHConst.appTitle)
+        : defaultAppDocPath;
     tempPath = (await getTemporaryDirectory()).path;
     extStorePath = Platform.isAndroid || Platform.isFuchsia
         ? (await getExternalStorageDirectory())?.path ?? ''
@@ -175,7 +178,11 @@ class Global {
 
     await GStore.init();
 
-    await hiveHelper.init();
+    if (Platform.isWindows) {
+      await hiveHelper.init(EHConst.appTitle);
+    } else {
+      await hiveHelper.init();
+    }
     await hiveCacheHelper.init();
     await isarHelper.initIsar();
 

--- a/lib/store/hive/hive.dart
+++ b/lib/store/hive/hive.dart
@@ -33,8 +33,8 @@ class HiveHelper {
   static final _galleryCacheBox = Hive.box<String>(galleryCacheBox);
   static final _configBox = Hive.box<String>(configBox);
 
-  Future<void> init() async {
-    await Hive.initFlutter();
+  Future<void> init([String? subDir]) async {
+    await Hive.initFlutter(subDir);
     await Hive.openBox<String>(
       historyBox,
       compactionStrategy: (int entries, int deletedEntries) {


### PR DESCRIPTION
To call `getApplicationDocumentsDirectory()` will return a path to `%USERPROFICE%\Documents` on `Windows`.
The path is dedicated to a user and is not specific for the app, and writring to this directory directly may confict with stuffs generated by other apps.
This PR will add a subdirectory named after `EHConst.appTitle` under the returned path for the data specific for this app to avoid the conficts and separate the data generated by this app from other apps to make migration and monitoring easier.

Before the fix:
<img width="301" alt="before" src="https://user-images.githubusercontent.com/17916222/203511383-a4b788a1-4d11-43f8-bdc4-5cb6c1ffa7fd.png">

After the fix:
<img width="179" alt="after1" src="https://user-images.githubusercontent.com/17916222/203511584-63126ce5-3c0c-428b-8ef2-20a0f38efb86.png">
<img width="213" alt="after2" src="https://user-images.githubusercontent.com/17916222/203511609-e02bf689-20e5-4acc-98a5-f28effffaa24.png">
